### PR TITLE
Launch Godot after tests on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ The player has placeholder slots for gloves, helmet, pants and cloak.
 
 ## Testing on Windows
 Windows users can double click `windows_tester\run_tests.bat` to install
-dependencies and run the Python tests automatically.
+dependencies, run the Python tests, and launch the game (requires Godot on PATH).

--- a/windows_tester/run_tests.bat
+++ b/windows_tester/run_tests.bat
@@ -1,4 +1,6 @@
 @echo off
 pip install -r ..\requirements.txt
 python ..\run_tests.py
+echo Launching game...
+godot ..\project.godot
 pause


### PR DESCRIPTION
## Summary
- Update Windows batch script to open the Godot project after running tests.
- Document the combined test-and-play workflow for Windows users.

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc94e54adc8332a8e501a05e5f42b6